### PR TITLE
Remove redundant file close

### DIFF
--- a/fuzzbuster.py
+++ b/fuzzbuster.py
@@ -59,7 +59,6 @@ def fuzz(url: str, wordlist: str) -> list:
                     total_words += 1
             except Exception as e:
                 pass
-        wordlist.close()
 
         with alive_bar(total_words, title=f'Scanning Target', bar='smooth', enrich_print=False) as bar:
             with open(wlist, 'r', errors="surrogateescape") as wordlist:


### PR DESCRIPTION
## Summary
- remove extraneous `wordlist.close()` in the fuzzer

## Testing
- `python -m py_compile fuzzbuster.py Core/*.py subdomainfuzzbuster.py`

------
https://chatgpt.com/codex/tasks/task_e_6856202f2aac8323ba1840823fed56b7